### PR TITLE
Track2 Chat updates for Fall 2015

### DIFF
--- a/THE-CHAT-RETURNS.md
+++ b/THE-CHAT-RETURNS.md
@@ -13,9 +13,9 @@ message content of their choosing.
 Because of the anonymous nature our the chat application, it quickly
 becomes very popular.  Because the application does not attempt to limit
 the length of the conversation history, it soon runs out of available
-memory and stops accepting new messages.  This leads frequently restarting
-the program, losing all messages, and fielding complaints from the users
-of the system.
+memory and stops accepting new messages.  This necessitates frequently
+restarting the program, losing all messages, and fielding complaints from
+the users of the system.
 
 ### The Quest
 After an in-depth study of the problem, it is determined that the
@@ -148,13 +148,13 @@ the code has an imperative flow to it.
         counts   (.get conversation :counts)
         messages (.get conversation :messages)]
 
-    (doto counts
-      (.put name (inc (.getOrDefault counts name 0))))
+    (.put counts
+      name (inc (.getOrDefault counts name 0)))
 
-    (doto messages
-      (.addFirst (doto (new HashMap)
-                   (.put :name name)
-                   (.put :message new-message))))
+    (.addFirst messages
+      (doto (new HashMap)
+            (.put :name name)
+            (.put :message new-message)))
 
     (loop []
       (when (< limit (.size messages))

--- a/project.clj
+++ b/project.clj
@@ -1,16 +1,15 @@
 (defproject chatter "0.1.0-SNAPSHOT"
   :description "A web app for displaying posted messages"
-  :url "http://example.com/FIXME"
   :min-lein-version "2.0.0"
-    :dependencies [[org.clojure/clojure "1.6.0"]
-                   [compojure "1.3.4"]
+    :dependencies [[org.clojure/clojure "1.7.0"]
+                   [compojure "1.4.0"]
                    [ring/ring-defaults "0.1.5"]
-                   [ring-server "0.4.0"]
+                   [ring/ring-core "1.4.0"]
+                   [ring/ring-jetty-adapter "1.4.0"]
                    [hiccup "1.0.5"]
-                   [clj-http "1.1.2"]
-                   [enlive "1.1.5"]]
-  :plugins [[lein-ring "0.8.13" :exclusions [org.clojure/clojure]]]
+                   [clj-http "2.0.0"]
+                   [enlive "1.1.6"]]
+  :plugins [[lein-ring "0.9.6" :exclusions [org.clojure/clojure]]]
   :ring {:handler chatter.handler/app}
-  :profiles
-  {:dev {:dependencies [[javax.servlet/servlet-api "2.5"]
-                        [ring-mock "0.1.5"]]}})
+  :profiles {:dev {:dependencies [[ring/ring-mock "0.2.0"]]}}
+  )

--- a/src/chatter/handler.clj
+++ b/src/chatter/handler.clj
@@ -2,19 +2,30 @@
   (:require [clojure.test   :refer [deftest run-tests is are]]
             [compojure.core :refer :all]
             [compojure.route :as route]
+            [ring.adapter.jetty :as jetty]
             [ring.middleware.defaults :refer [wrap-defaults site-defaults]]
-            [ring.middleware.params :refer [wrap-params]]
-            [ring.server.standalone :as server]
+            [ring.middleware.params   :refer [wrap-params]]
             [hiccup.page :as page])
 
   (:import  [java.util HashMap LinkedList Map]
             [java.util.concurrent ConcurrentHashMap
                                   ConcurrentLinkedDeque]))
 
+
+
 (defn new-mutable-conversation-db
   "Using simple, mutable Java collections, construct a new
 Conversation Database that will hold a limited number of messages."
   [message-limit]
+  ;;;;;  Comments show comparable Java source
+  ;;
+  ;; HashMap conversation = new Conversation();
+  ;; conversation.put( :limit, message-limit );
+  ;; conversation.put( :total, 0 );
+  ;; conversation.put( :counts, new HashMap() );
+  ;; conversation.put( :messages, new LinkedList() );
+  ;; return conversation;
+
   (doto (new HashMap)
     (.put :limit    message-limit)
     (.put :total    0)
@@ -22,30 +33,49 @@ Conversation Database that will hold a limited number of messages."
     (.put :messages (new LinkedList))))
 
 
+
 (defn mutating-add-message
   "Using standard Java collections APIs, add a new message
 to a conversation and perform all necessary accounting."
   [conversation name new-message]
+  ;;;;;  Comments show comparable Java source
+  ;;
+  ;; Integer limit = (Integer) conversation.get( :limit );
+  ;; Integer total = (Integer) conversation.get( :total );
+  ;; Map counts    = (Map) conversation.get( :counts );
+  ;; List          = (List) messages = conversation.get( :messages );
   (let [limit    (.get conversation :limit)
         total    (.get conversation :total)
         counts   (.get conversation :counts)
         messages (.get conversation :messages)]
 
-    (doto counts
-      (.put name (inc (.getOrDefault counts name 0))))
+    ;; counts.put( name,
+    ;;             1 + counts.getOrDefault( name, 0 ) );
+    (.put counts
+      name (inc (.getOrDefault counts name 0)))
 
-    (doto messages
-      (.addFirst (doto (new HashMap)
-                   (.put :name name)
-                   (.put :message new-message))))
+    ;; Map tmp = new HashMap();
+    ;; tmp.put( :name, name );
+    ;; tmp.put( :message, new-message );
+    ;; messages.addFirst( tmp );
+    (.addFirst messages
+      (doto (new HashMap)
+            (.put :name name)
+            (.put :message new-message)))
 
+    ;; while( limit < messages.size() ) {
+    ;;    messages.removeLast();
+    ;; }
     (loop []
       (when (< limit (.size messages))
             (.removeLast messages)
             (recur)))
 
+    ;; conversation.put( :total, 1 + total );
+    ;; return conversation;
     (doto conversation
       (.put :total (inc total)))))
+
 
 
 (defn new-mutable-concurrent-conversation-db
@@ -60,6 +90,7 @@ of messages"
     (.put :messages (new ConcurrentLinkedDeque))))
 
 
+
 (defn locking-add-message
   "Add a message to a conversation after locking
 the conversation"
@@ -67,13 +98,19 @@ the conversation"
   (locking conversation
     (mutating-add-message conversation name message)))
 
+
+
 (def safe-inc
   "Increments a number.  Treats nil as 0"
   (fnil inc 0))
 
+
+
 (defn new-immutable-conversation-db
   [message-limit]
   {:limit message-limit})
+
+
 
 (defn immutable-add-message
   "Uses immutable Clojure collections to combine a
@@ -86,21 +123,31 @@ conversation and a new message into a new conversation"
                    (cons {:name name :message message}
                          messages))})
 
+
+
 (defn new-atomic-conversation-db
   "Construct a new Atomic Conversation Database: 
 Conversation data wrapped in an Atom"
   [message-limit]
   (atom (new-immutable-conversation-db message-limit)))
 
+
+
 (defn atomic-add-message
   "Add a message to an Atomic Conversation Database"
   [conversation-atom name message]
   (swap! conversation-atom immutable-add-message name message))
 
-(defn desc-sort-by [keyfn coll]
+
+
+(defn desc-sort-by
+  "Sort a collection in descending order based on the
+result of applying key-fn to each member."
+  [keyfn coll]
   (sort-by keyfn
            (fn [a b] (compare b a))
            coll))
+
 
 
 (defn input-text
@@ -114,6 +161,8 @@ Conversation data wrapped in an Atom"
       {:type "text" :name name
        :placeholder label
        :value value}]]))
+
+
 
 (defn generate-message-view
   "This generates the HTML for displaying messages"
@@ -150,7 +199,7 @@ Conversation data wrapped in an Atom"
           [:table#messages.table.table-striped.table-condensed
            (map (fn [m] [:tr [:td.name (:name m)]
                              [:td.message (:message m)]])
-                (reverse (:messages conversation)))]]
+                (:messages conversation))]]
 
          [:div.col-xs-4.col-md-3.col-lg-3
           [:h3 "Stats"]
@@ -164,20 +213,34 @@ Conversation data wrapped in an Atom"
                       (desc-sort-by
                         val (:counts conversation))))]]]]])))
 
+
+
+
 (defonce CONVERSATION-DB
   (new-mutable-conversation-db 20))
 
+(defn reset-conversation-db
+  [constructor & constructor-args]
+  (alter-var-root #'CONVERSATION-DB
+                  (constantly
+                    (apply constructor constructor-args))))
+
+
+
 (defroutes app-routes
-  (GET "/" [] (generate-message-view CONVERSATION-DB))
-  (POST "/" {params :params}
-    (let [name-param (get params "name")
-          msg-param (get params "msg")
+  (GET  "/" []
+    (generate-message-view CONVERSATION-DB))
+  (POST "/"
+    {params :params}
+    (let [name-param   (get params "name")
+          msg-param    (get params "msg")
           new-messages (mutating-add-message CONVERSATION-DB
-                                             name-param msg-param)]
+                         name-param msg-param)]
       (generate-message-view new-messages name-param)
       ))
   (route/resources "/")
-  (route/not-found "Not Found"))
+  (route/not-found "This is not the page you are looking for"))
+
 
 
 (defn wrap-with-lock
@@ -186,6 +249,7 @@ Conversation data wrapped in an Atom"
   (fn [request]
     (locking CONVERSATION-DB
       (handler request))))
+
 
 
 (def app
@@ -201,7 +265,10 @@ Conversation data wrapped in an Atom"
   (swap! SERVER
          (fn [s]
            (if (nil? s)
-              (server/serve #'app {:port 8000})
+              (jetty/run-jetty #'app
+                {:join? false
+                 :port 3000
+                 :host "0.0.0.0"})
               s))))
 
 (defn stop-server

--- a/test/chatter/handler_test.clj
+++ b/test/chatter/handler_test.clj
@@ -16,10 +16,13 @@
     (let [response (app (mock/request :get "/invalid"))]
       (is (= (:status response) 404)))))
 
+
+
 (deftest test-safe-inc
   (is (= 1 (safe-inc nil)))
   (is (= 1 (safe-inc 0)))
   (is (= 2 (safe-inc 1))))
+
 
 
 (defn simulate-conversation
@@ -44,7 +47,9 @@ Arguments:
     conv))
 
 
+
 (deftest parallel-add-messages
+  "Run Conversation Simulations and verify the results."
   (let [messages 50000
         message-limit 20]
     (are [constructor add-message extract]
@@ -75,9 +80,9 @@ Arguments:
                        'constructor 'add-message)))
 
          ;;  This will likely throw exceptions and not work at all
-         ;new-mutable-conversation-db
-         ;mutating-add-message
-         ;identity
+         new-mutable-conversation-db
+         mutating-add-message
+         identity
 
          ;;  This won't throw exceptions, but usually fails with
          ;;  random, wrong results
@@ -86,9 +91,9 @@ Arguments:
          ;identity
 
          ;;  This should work
-         new-mutable-conversation-db
-         locking-add-message
-         identity
+         ;new-mutable-conversation-db
+         ;locking-add-message
+         ;identity
 
          ;;  This should work too
          ;new-mutable-concurrent-conversation-db
@@ -102,6 +107,7 @@ Arguments:
          )))
 
 
+
 (defn integer-value
   "Convert a string or other value into an integer"
   [x]
@@ -110,6 +116,7 @@ Arguments:
                       (catch Exception e 0))
         (nil? x)    0
         :else       (recur (str x))))
+
 
 
 (defn extract-chat-messages
@@ -123,6 +130,7 @@ Arguments:
        :message (first msgs)})))
 
 
+
 (defn extract-chat-user-counts
   "Extract the per-user message counts from the HTML of a chat page"
   [chat-html]
@@ -133,6 +141,7 @@ Arguments:
             [names  [:td.name html/text]
              counts [:td.count html/text]]
             [(first names) (integer-value (first counts))]))))
+
 
 
 (defn parse-chat-response
@@ -150,6 +159,7 @@ conversation data"
      :total       total}))
 
 
+
 (defn post-message
   "Post a new message to a chat server.
 Returns the HTML response converted back into conversation data."
@@ -159,12 +169,14 @@ Returns the HTML response converted back into conversation data."
                     :as :stream})))
 
 
+
 (defn read-messages
   "Read the current messages on a chat server.
 Returns the HTML response converted back into conversation data."
   [url]
   (parse-chat-response
     (http/get url {:as :stream})))
+
 
 
 (defn post-message-and-check
@@ -182,6 +194,7 @@ Returns the HTML response converted back into conversation data."
     ))
 
 
+
 (defn chat-bot [url message-count names messages]
   (doall
     (pmap (partial post-message-and-check url)
@@ -189,7 +202,7 @@ Returns the HTML response converted back into conversation data."
           (take message-count (cycle messages))))
   (read-messages url))
 
-#_(chat-bot "http://localhost:8000/"
+#_(chat-bot "http://localhost:3000/"
            50
            ["Thing One" "Thing Two"]
            ["They can"


### PR DESCRIPTION
For the Fall 2015 Clojurebridge session, I have a few small changes:
- Updating dependencies:
  - Clojure 1.7 has been released
  - Ring has been updated to 1.4 which finally ditches a four year old version of Jetty
- Added comments with comparison Java code to some functions to illustrate the transition from semi-colon delimited statements to parenthetical expressions.
- More whitespace for presentation viewing.
